### PR TITLE
README: add telnet/ftp flash steps, Tvheadend note

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ allows you to:
  - Schedule programmes for recording.
 
  - Filter, demux and reencode streams.
+ 
+ - The Tvheadend server may need to be started with an argument
+   `--bindaddr $IPADDRESS` to detect SAT>IP tuners. See [issue.](https://github.com/openwrt/packages/issues/16500)
 
 And many more.
 
@@ -33,7 +36,7 @@ as an SSH server), change the default root password and more.
 Some important things to consider:
 
  - **The firmware is provided without warranty of any kind.**
-   It's been tested on multiple DM500S STBs though, and if it
+   It's been tested on multiple DM500S including clones, and if it
    doesn't work you should be able to flash another image.
    **It has no time bombs** (see last section).
 
@@ -47,7 +50,58 @@ Some important things to consider:
    guaranteeing anything though).
 
 If you aren't flashing via DreamUp, make sure you flash to partition
-0 (labeled "CramFS + SquashFS" or similar).
+0 (labeled "CramFS + SquashFS" or similar) using instructions below.
+
+Logon to dreambox via 'telnet' and check if hardware info matches:
+```
+uname -a
+#Linux dreambox 2.6.9 #3 Sun Apr 27 20:01:34 WEST 2008 ppc unknown
+
+cat /proc/mtd
+#dev:    size   erasesize  name
+#mtd0: 00600000 00020000 "DreamBOX cramfs+squashfs"
+#mtd1: 001c0000 00020000 "DreamBOX jffs2"
+#mtd2: 00040000 00020000 "DreamBOX OpenBIOS"
+#mtd3: 007c0000 00020000 "DreamBOX (w/o bootloader)"
+#mtd4: 00800000 00020000 "DreamBOX (w/ bootloader)"
+#mtd5: 004e0000 00020000 "DreamBOX SquashedFS"
+#mtd6: 00120000 00020000 "DreamBOX Cramfs"
+
+cat /proc/cpuinfo 
+#processor	: 0
+#cpu		: STBx25xx
+#clock		: 252MHz
+#revision	: 9.80 (pvr 5151 0950)
+#bogomips	: 250.88
+#machine		: Dream Multimedia TV Dreambox
+#plb bus clock	: 63MHz
+
+df -h
+#Filesystem                Size      Used Available Use% Mounted on
+#/dev/root                 3.9M      3.9M         0 100% /
+#/dev/mtdblock/1           1.8M    448.0k      1.3M  25% /var
+
+free
+#              total         used         free       shared      buffers
+#  Mem:        30184        23096         7088            0         2348
+# Swap:            0            0            0
+#Total:        30184        23096         7088
+```
+Before flashing its good practice to backup mtd0-6. With 'telnet' copy 
+each mtd to '/tmp/' and transfer it via FileZilla:
+```
+cat /dev/mtd/0 > /tmp/mtd0 #creates backup of first partition takes time!
+#Back it up with FileZilla and remove when done via FileZilla or telnet
+rm /tmp/mtd0
+
+#repeat previous steps for mtd1 mtd2 mtd3 mtd4 mtd5 mtd6
+#remove has to be done 1 at the time otherwise space will run out!
+```
+If you backed up all mtd0-6 and transfered the replacement firmware image
+'dm500-satip-2.3.img' back via FileZilla to '/tmp/' flash with following command:
+```
+eraseall /dev/mtd/0 && cp /tmp/dm500-satip-2.3.img /dev/mtd/0;sync;#reboot
+```
 
 ### The static version
 


### PR DESCRIPTION
When not using the DreamUp flash tool, these telnet/ftp instructions will do the job. Also added a note on detecting SAT>IP tuners in Tvheadend using `--bindaddr $TVHEADENDSERVER-IPADDRESS`.